### PR TITLE
Groups: add membership URL to Group actor

### DIFF
--- a/src/main/java/smithereen/data/Group.java
+++ b/src/main/java/smithereen/data/Group.java
@@ -70,6 +70,7 @@ public class Group extends Actor{
 	public JsonObject asActivityPubObject(JsonObject obj, ContextCollector contextCollector){
 		obj=super.asActivityPubObject(obj, contextCollector);
 
+		String userURL=activityPubID.toString();
 		JsonArray ar=new JsonArray();
 		for(GroupAdmin admin : adminsForActivityPub){
 			JsonObject ja=new JsonObject();
@@ -80,6 +81,9 @@ public class Group extends Actor{
 			ar.add(ja);
 		}
 		obj.add("attributedTo", ar);
+
+		obj.addProperty("members", userURL+"/followers");
+		contextCollector.addType("members", "sm:members", "@id");
 
 		return obj;
 	}


### PR DESCRIPTION
I'm developing a [groups implementation](https://git.pleroma.social/alexgleason/pleroma/-/merge_requests/4) based around Joins and membership. Based on what I understand, Smithereen uses Follow to join, and its followers are considered its members.

I added a "members" key to the Group actor, pointing to its followers URI so they can interoperate. Hopefully I did this correctly.