### PR TITLE
fix: Don't call halt in shutdown hook

### DIFF
--- a/src/main/java/smithereen/SmithereenApplication.java
+++ b/src/main/java/smithereen/SmithereenApplication.java
@@ -599,8 +599,6 @@ public class SmithereenApplication{
 			try{
 				BackgroundTaskRunner.shutDown();
 			}catch(NoClassDefFoundError ignore){}
-			// Set the exit code to 0 so systemd doesn't say "Failed with result 'exit-code'".
-			Runtime.getRuntime().halt(0);
 		}));
 	}
 


### PR DESCRIPTION
Calling halt prevents any other shutdown hooks from running, which can interfere with operation of other code such as Java agents.