### PR TITLE
Allow passing arguments to Maven via MAVEN_OPTS environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM maven:3.8.6-eclipse-temurin-17 as builder
 
 WORKDIR /usr/src/app
 COPY . .
+ARG MAVEN_OPTS
 RUN mvn package -DskipTests=true
 RUN java LibVipsDownloader.java
 


### PR DESCRIPTION
This is useful, for example, when you need to force Maven work through a proxy.