### PR TITLE
Use salt for storing passwords in the database

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE `accounts` (
   `user_id` int unsigned NOT NULL,
   `email` varchar(200) NOT NULL DEFAULT '',
   `password` binary(32) DEFAULT NULL,
+  `salt` binary(32) DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `invited_by` int unsigned DEFAULT NULL,
   `preferences` text,

--- a/src/main/java/smithereen/storage/SessionStorage.java
+++ b/src/main/java/smithereen/storage/SessionStorage.java
@@ -7,10 +7,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.sql.PreparedStatement;
@@ -20,6 +18,7 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
@@ -28,7 +27,6 @@ import java.util.Objects;
 import smithereen.Config;
 import smithereen.LruCache;
 import smithereen.Utils;
-import smithereen.exceptions.InternalServerErrorException;
 import smithereen.model.Account;
 import smithereen.model.AdminNotifications;
 import smithereen.model.EmailCode;
@@ -47,6 +45,7 @@ import smithereen.model.notifications.Notification;
 import smithereen.storage.sql.DatabaseConnection;
 import smithereen.storage.sql.DatabaseConnectionManager;
 import smithereen.storage.sql.SQLQueryBuilder;
+import smithereen.util.Passwords;
 import spark.Request;
 import spark.Session;
 
@@ -130,20 +129,24 @@ public class SessionStorage{
 
 	public static Account getAccountForUsernameAndPassword(@NotNull String usernameOrEmail, @NotNull String password) throws SQLException{
 		try(DatabaseConnection conn=DatabaseConnectionManager.getConnection()){
-			byte[] hashedPassword=hashPassword(password);
 			PreparedStatement stmt;
 			if(usernameOrEmail.contains("@")){
-				stmt=conn.prepareStatement("SELECT * FROM `accounts` WHERE `email`=? AND `password`=?");
+				stmt=conn.prepareStatement("SELECT * FROM `accounts` WHERE `email`=?");
 			}else{
-				stmt=conn.prepareStatement("SELECT * FROM `accounts` WHERE `user_id` IN (SELECT `id` FROM `users` WHERE `username`=?) AND `password`=?");
+				stmt=conn.prepareStatement("SELECT * FROM `accounts` WHERE `user_id` IN (SELECT `id` FROM `users` WHERE `username`=?)");
 			}
 			stmt.setString(1, usernameOrEmail);
-			stmt.setBytes(2, hashedPassword);
 			try(ResultSet res=stmt.executeQuery()){
-				if(res.next()){
-					return Account.fromResultSet(res);
+				if(!res.next()){
+					return null;
 				}
-				return null;
+				byte[] correctPassword=res.getBytes("password");
+				byte[] salt=res.getBytes("salt");
+				byte[] enteredPassword=Passwords.hashPasswordWithSalt(password, salt);
+				if(!Arrays.equals(enteredPassword, correctPassword)){
+					return null;
+				}
+				return Account.fromResultSet(res);
 			}
 		}
 	}
@@ -167,15 +170,6 @@ public class SessionStorage{
 				.deleteFrom("sessions")
 				.where("id=? AND account_id=?", (Object) sid, accountID)
 				.executeNoResult();
-	}
-
-	private static byte[] hashPassword(String password){
-		try{
-			MessageDigest md=MessageDigest.getInstance("SHA-256");
-			return md.digest(password.getBytes(StandardCharsets.UTF_8));
-		}catch(NoSuchAlgorithmException x){
-			throw new InternalServerErrorException(x);
-		}
 	}
 
 	public static SignupResult registerNewAccount(@Nullable String username, @NotNull String password, @NotNull String email, @NotNull String firstName, @NotNull String lastName, @NotNull User.Gender gender, @NotNull String invite) throws SQLException{
@@ -227,15 +221,17 @@ public class SessionStorage{
 							.executeNoResult();
 				}
 
-				byte[] hashedPassword=hashPassword(password);
-				stmt=conn.prepareStatement("INSERT INTO `accounts` (`user_id`, `email`, `password`, `invited_by`) VALUES (?, ?, ?, ?)");
+				byte[] salt=Passwords.randomSalt();
+				byte[] hashedPassword=Passwords.hashPasswordWithSalt(password, salt);
+				stmt=conn.prepareStatement("INSERT INTO `accounts` (`user_id`, `email`, `password`, `salt`, `invited_by`) VALUES (?, ?, ?, ?, ?)");
 				stmt.setInt(1, userID);
 				stmt.setString(2, email);
 				stmt.setBytes(3, hashedPassword);
+				stmt.setBytes(4, salt);
 				if(inviterAccountID!=0)
-					stmt.setInt(4, inviterAccountID);
+					stmt.setInt(5, inviterAccountID);
 				else
-					stmt.setNull(4, Types.INTEGER);
+					stmt.setNull(5, Types.INTEGER);
 				stmt.execute();
 
 				int inviterUserID=0;
@@ -314,12 +310,14 @@ public class SessionStorage{
 							.executeNoResult();
 				}
 
-				byte[] hashedPassword=hashPassword(password);
-				stmt=conn.prepareStatement("INSERT INTO `accounts` (`user_id`, `email`, `password`, `invited_by`) VALUES (?, ?, ?, ?)");
+				byte[] salt=Passwords.randomSalt();
+				byte[] hashedPassword=Passwords.hashPasswordWithSalt(password, salt);
+				stmt=conn.prepareStatement("INSERT INTO `accounts` (`user_id`, `email`, `password`, `salt`, `invited_by`) VALUES (?, ?, ?, ?, ?)");
 				stmt.setInt(1, userID);
 				stmt.setString(2, email);
 				stmt.setBytes(3, hashedPassword);
-				stmt.setNull(4, Types.INTEGER);
+				stmt.setBytes(4, salt);
+				stmt.setNull(5, Types.INTEGER);
 				stmt.execute();
 
 				conn.createStatement().execute("COMMIT");
@@ -342,11 +340,15 @@ public class SessionStorage{
 	}
 
 	public static boolean updatePassword(int accountID, String oldPassword, String newPassword) throws SQLException{
-		byte[] hashedOld=hashPassword(oldPassword);
-		byte[] hashedNew=hashPassword(newPassword);
+		byte[] oldSalt=getSaltFromDatabase(accountID);
+		if(oldSalt==null) return false;
+		byte[] hashedOld=Passwords.hashPasswordWithSalt(oldPassword, oldSalt);
+		byte[] newSalt=Passwords.randomSalt();
+		byte[] hashedNew=Passwords.hashPasswordWithSalt(newPassword, newSalt);
 		return new SQLQueryBuilder()
 				.update("accounts")
 				.value("password", hashedNew)
+				.value("salt", newPassword)
 				.where("id=? AND `password`=?", accountID, hashedOld)
 				.executeUpdate()==1;
 	}
@@ -462,16 +464,31 @@ public class SessionStorage{
 	}
 
 	public static boolean updatePassword(int accountID, String newPassword) throws SQLException{
-		byte[] hashedNew=hashPassword(newPassword);
+		byte[] salt=Passwords.randomSalt();
+		byte[] hashedNew=Passwords.hashPasswordWithSalt(newPassword, salt);
 		return new SQLQueryBuilder()
 				.update("accounts")
 				.value("password", hashedNew)
+				.value("salt", salt)
 				.where("id=?", accountID)
 				.executeUpdate()==1;
 	}
 
+	private static byte @Nullable [] getSaltFromDatabase(int accountID) throws SQLException{
+		try(ResultSet res=new SQLQueryBuilder()
+				.selectFrom("accounts")
+				.columns("salt")
+				.where("id=?", accountID)
+				.execute()){
+			if(!res.next()) return null;
+			return res.getBytes(0);
+		}
+	}
+
 	public static boolean checkPassword(int accountID, String password) throws SQLException{
-		byte[] hashed=hashPassword(password);
+		byte[] salt=getSaltFromDatabase(accountID);
+		if(salt==null) return false;
+		byte[] hashed=Passwords.hashPasswordWithSalt(password, salt);
 		return new SQLQueryBuilder()
 				.selectFrom("accounts")
 				.count()

--- a/src/main/java/smithereen/util/Passwords.java
+++ b/src/main/java/smithereen/util/Passwords.java
@@ -1,0 +1,56 @@
+package smithereen.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import smithereen.exceptions.InternalServerErrorException;
+
+public class Passwords{
+	private Passwords(){
+	}
+
+	private static final SecureRandom random=new SecureRandom();
+	private static final String DEFAULT_HASHING_ALGORITHM="SHA-256";
+
+	public static byte @NotNull [] randomSalt(){
+		byte[] salt=new byte[32];
+		random.nextBytes(salt);
+		return salt;
+	}
+
+	public static byte @NotNull [] saltedPassword(byte @NotNull [] hashedPassword, byte @NotNull [] salt){
+		byte[] passwordAndSalt=new byte[hashedPassword.length+salt.length];
+		System.arraycopy(hashedPassword, 0, passwordAndSalt, 0, hashedPassword.length);
+		System.arraycopy(salt, 0, passwordAndSalt, hashedPassword.length, salt.length);
+		try{
+			MessageDigest md=MessageDigest.getInstance(DEFAULT_HASHING_ALGORITHM);
+			return md.digest(passwordAndSalt);
+		}catch(NoSuchAlgorithmException x){
+			throw new InternalServerErrorException(x);
+		}
+	}
+
+	/**
+	 * Returns the hashed password according to the following formula: <code>sha256(sha256(password) + salt)</code>.
+	 * The proper way would be to just use <code>sha256(password + salt)</code>, but the older versions of the database
+	 * used to contain only hashed passwords without any salt, we have to be able to migrate those.
+	 *
+	 * @param password The user password.
+	 * @param salt     A random string of bytes. Should be at least 32 bytes long, otherwise it's not secure enough.
+	 * @return The salted and hashed password.
+	 */
+	public static byte @NotNull [] hashPasswordWithSalt(@NotNull String password, byte @NotNull [] salt){
+		byte[] hashedPassword;
+		try{
+			MessageDigest md=MessageDigest.getInstance(DEFAULT_HASHING_ALGORITHM);
+			hashedPassword=md.digest(password.getBytes(StandardCharsets.UTF_8));
+		}catch(NoSuchAlgorithmException x){
+			throw new InternalServerErrorException(x);
+		}
+		return saltedPassword(hashedPassword, salt);
+	}
+}

--- a/src/main/java/smithereen/util/Passwords.java
+++ b/src/main/java/smithereen/util/Passwords.java
@@ -22,16 +22,20 @@ public class Passwords{
 		return salt;
 	}
 
+	private static byte[] sha256(byte[] input){
+		try{
+			MessageDigest md=MessageDigest.getInstance("SHA-256");
+			return md.digest(input);
+		}catch(NoSuchAlgorithmException x){
+			throw new InternalServerErrorException(x);
+		}
+	}
+
 	public static byte @NotNull [] saltedPassword(byte @NotNull [] hashedPassword, byte @NotNull [] salt){
 		byte[] passwordAndSalt=new byte[hashedPassword.length+salt.length];
 		System.arraycopy(hashedPassword, 0, passwordAndSalt, 0, hashedPassword.length);
 		System.arraycopy(salt, 0, passwordAndSalt, hashedPassword.length, salt.length);
-		try{
-			MessageDigest md=MessageDigest.getInstance(DEFAULT_HASHING_ALGORITHM);
-			return md.digest(passwordAndSalt);
-		}catch(NoSuchAlgorithmException x){
-			throw new InternalServerErrorException(x);
-		}
+		return sha256(passwordAndSalt);
 	}
 
 	/**
@@ -44,13 +48,6 @@ public class Passwords{
 	 * @return The salted and hashed password.
 	 */
 	public static byte @NotNull [] hashPasswordWithSalt(@NotNull String password, byte @NotNull [] salt){
-		byte[] hashedPassword;
-		try{
-			MessageDigest md=MessageDigest.getInstance(DEFAULT_HASHING_ALGORITHM);
-			hashedPassword=md.digest(password.getBytes(StandardCharsets.UTF_8));
-		}catch(NoSuchAlgorithmException x){
-			throw new InternalServerErrorException(x);
-		}
-		return saltedPassword(hashedPassword, salt);
+		return saltedPassword(sha256(password.getBytes(StandardCharsets.UTF_8)), salt);
 	}
 }


### PR DESCRIPTION
This is a much more secure way to store users' passwords. For example, if we are not using salt and two different users happen to have the same password, the hashes stored in the DB will also be the same, which is something that an attacker with the access to the DB can use.

Also, if the user uses a not strong enough a password, the attacker with the access to the DB may be able to recover the password using rainbow tables.

Using salt will help prevent those kinds of attacks.

More info on that:
[http://www.aspheute.com/english/20040105.asp](https://web.archive.org/web/20220326062813/http://www.aspheute.com/english/20040105.asp)