### PR TITLE
Improve email style

### DIFF
--- a/src/main/resources/templates/email/page.twig
+++ b/src/main/resources/templates/email/page.twig
@@ -2,15 +2,56 @@
 <html>
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+	<style type="text/css">
+		a {
+			color: #485C00; /* $normalLink */
+			text-decoration: none;
+			cursor: pointer;
+		}
+		a:hover {
+			text-decoration: underline;
+		}
+		h1 {
+			margin: 2px 0 15px;
+			padding: 0 0 4px;
+			border-bottom: 1px solid #ECEBE2; /* $mainHeaderSeparator */
+			color: #4E7000; /* $boldHeaders */
+			font-size: 100%;
+		}
+		.button_blue a:hover {
+			background-position: 0 -8px;
+		}
+		.button_blue a:active {
+			background: linear-gradient(to top, #607D00 /* $buttonGradientBottom */, #8F9F44 /* $buttonBorderTop */) repeat-x top;
+			border: 1px solid #648900; /* $buttonBorder */
+			position: relative;
+		}
+	</style>
 </head>
-<body bgcolor="#FFFFFF">
-<table cellpadding="5" cellspacing="0" border="0" width="100%" style="font-family: Tahoma, Arial, sans-serif; font-size: 11px;">
-	<tr bgcolor="#4E6C1A">
-		<td width="27"><img src="https://{{ domain }}/res/email_logo.png" width="27" height="28"/></td>
-		<td valign="middle" style="font-weight: bold; color: #FFFFFF;">{{ serverName }}</td>
-	</tr>
+<body style="margin:0;padding:0;font-family:Tahoma,Arial,sans-serif;font-size:12px;font-weight:normal;">
+<table cellspacing="0" cellpadding="0" width="100%" bgcolor="#F5F5F5">
 	<tr>
-		<td colspan="2">{% block content %}{% endblock %}</td>
+		<td width="5%"></td>
+		<td width="90%" style="padding:15px 0;">
+			<table cellspacing="0" cellpadding="0" width="100%" style="border-radius: 5px; overflow:hidden">
+				<tr>
+					<td style="background: linear-gradient(to top, #698600 /* $headerGradientBottom */, #4C6E00 /* $headerGradientTop */), repeat-x top;">
+						<a href="https://{{ domain }}" style="color:#FFFFFF;font-size:14px;font-weight:bold;height:43px;line-height:43px;max-height:43px;text-decoration:none">
+							<img src="https://{{ domain }}/res/desktop_logo_v1.svg" alt="Smithereen" height="28" width="27" border="0" style="vertical-align:middle;margin:0 8px 0 8px"/>
+							{{ serverName }}
+						</a>
+					</td>
+				</tr>
+				<tr bgcolor="#FFFFFF" style="border:1px solid #E4DFC1">
+					<td>
+						<div style="padding:18px 18px 13px 18px;font-size:12px;color:black;border:1px solid #E3E1CC;border-top:0;border-bottom-left-radius:5px;border-bottom-right-radius:5px;">
+							{% block content %}{% endblock %}
+						</div>
+					</td>
+				</tr>
+			</table>
+		</td>
+		<td width="5%"></td>
 	</tr>
 </table>
 </body>


### PR DESCRIPTION
Before:
<img width="1005" alt="Screenshot 2025-02-11 at 21 42 33" src="https://github.com/user-attachments/assets/c99e88ef-ad52-4344-9573-fd753d593872" />

After:
<img width="1015" alt="Screenshot 2025-02-12 at 01 20 33" src="https://github.com/user-attachments/assets/72b1e171-70f8-4e6e-82ce-18ffc4ab399e" />

Basically, the latter tries to very closely mimic the style of emails which VK used to send in around 2012–2013:
<img width="1014" alt="Screenshot 2025-02-12 at 00 53 05" src="https://github.com/user-attachments/assets/70fb10f8-9a8b-465f-b83f-8218c7ddc903" />