### PR TITLE
Disable text scaling in the mobile version

### DIFF
--- a/src/main/web/mobile.scss
+++ b/src/main/web/mobile.scss
@@ -15,6 +15,7 @@ body, html{
 
 body{
 	margin: 0;
+	text-size-adjust: none;
 }
 
 .pageContent{


### PR DESCRIPTION
Before:
<img width="896" alt="Screenshot 2025-03-08 at 13 23 42" src="https://github.com/user-attachments/assets/a370fc73-052b-489c-b729-b48f697d577f" />

After:
<img width="896" alt="Screenshot 2025-03-08 at 13 23 33" src="https://github.com/user-attachments/assets/efda9623-79a1-4ae3-95b8-161df156ddbc" />
