### PR TITLE
Fix the Host header in the example nginx config

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -20,7 +20,7 @@ server{
     }
     location / {
         proxy_pass http://127.0.0.1:4567;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
     }
     location /system/ws {


### PR DESCRIPTION
`$host` doesn't include the port number, while `$http_host` does.

This is important for redirections: when redirecting from (e.g. from `/` to `/feed`), Jetty takes the Host header from the original request. In dev environment, if the port is not 80, this would lead to redirection with the incorrect port number (80, the default).