### PR TITLE
Adjust padding & margins for post attachments

### DIFF
--- a/src/main/web/common.scss
+++ b/src/main/web/common.scss
@@ -409,7 +409,9 @@ textarea{
 }
 
 .postAttachments{
-	padding-top: 8px;
+	.aspectBoxW{
+		margin: 9px 0 4px;
+	}
 }
 
 .wallPostForm{


### PR DESCRIPTION
This is closer to what VK used to do.

This will also make audio attachments look nicer, since margins of nested elements (unlike padding)
don't add up, and the audio attachment list will have its own padding inside `postAttachments`.

Before:
<img width="630" alt="Screenshot 2025-03-13 at 01 14 00" src="https://github.com/user-attachments/assets/e7d1e7e8-0bcc-486c-a2a9-1c6d65c94dfd" />

After:
<img width="630" alt="Screenshot 2025-03-13 at 01 19 56" src="https://github.com/user-attachments/assets/11e92193-6749-4ff5-a808-80d97b235816" />

