### PR TITLE
Bump JS target version to ES2015

### DIFF
--- a/src/main/web/common_ts/tsconfig.json
+++ b/src/main/web/common_ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions":{
+		"target": "ES2015",
 		"outFile": "../../resources/public/res/common.js",
 		"sourceMap": true,
 		"sourceRoot": "/res/common_ts/",

--- a/src/main/web/graffiti_ts/tsconfig.json
+++ b/src/main/web/graffiti_ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions":{
+		"target": "ES2015",
 		"outFile": "../../resources/public/res/graffiti.js",
 		"sourceMap": true,
 		"sourceRoot": "/res/graffiti_ts/",

--- a/src/main/web/graph_ts/tsconfig.json
+++ b/src/main/web/graph_ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions":{
+		"target": "ES2015",
 		"outFile": "../../resources/public/res/graph.js",
 		"sourceMap": true,
 		"sourceRoot": "/res/graph_ts/",


### PR DESCRIPTION
It's been around for 10 years already, [all major browsers support it](https://caniuse.com/es6), and those that don't probably also don't support some web APIs that are currently being used in Smithereen.

This results in a smaller bundle size and unlocks further improvements in the bundle size once we modularize the JS code.

Before:
- 175782 bytes for `common.js`
- 10254 bytes for `graffiti.js`
- 34550 bytes for `graph.js`

After:
- 164081 byte for `common.js` (6.7% smaller)
- 8837 bytes for `graffiti.js` (13.8% smaller)
- 31971 byte for `graph.js` (7.5% smaller)