### PR TITLE
Fix missing graffiti editor after switching to ES6

### DIFF
--- a/src/main/web/common_ts/PostForm.ts
+++ b/src/main/web/common_ts/PostForm.ts
@@ -1,7 +1,10 @@
 ///<reference path="./PopupMenu.ts"/>
 
 interface GraffitiEditorBox extends Box{
-	(title:string, form:PostForm):GraffitiEditorBox;
+}
+
+interface Window {
+	GraffitiEditorBox:new(title:string, form:PostForm)=>GraffitiEditorBox;
 }
 
 interface UploadingAttachment{
@@ -647,12 +650,12 @@ class PostForm{
 	private showGraffitiEditor(args:any){
 		if(!this.checkAttachmentCount())
 			return;
-		if((window as any).GraffitiEditorBox!==undefined){
-			new (window as any).GraffitiEditorBox(args.title, this).show();
+		if(window.GraffitiEditorBox!==undefined){
+			new window.GraffitiEditorBox(args.title, this).show();
 		}else{
 			LayerManager.getInstance().showBoxLoader();
 			var script=ce("script", {src: "/res/graffiti.js?"+args.jsHash, onload:()=>{
-				new (window as any).GraffitiEditorBox(args.title, this).show();
+				new window.GraffitiEditorBox(args.title, this).show();
 			}});
 			document.body.appendChild(script);
 		}

--- a/src/main/web/graffiti_ts/GraffitiEditor.ts
+++ b/src/main/web/graffiti_ts/GraffitiEditor.ts
@@ -185,6 +185,12 @@ class GraffitiEditorBox extends Box{
 	}
 }
 
+interface Window {
+	GraffitiEditorBox:typeof GraffitiEditorBox;
+}
+
+window.GraffitiEditorBox = GraffitiEditorBox;
+
 class DrawingArea{
 	private wrap:HTMLDivElement;
 	private svg:SVGSVGElement;


### PR DESCRIPTION
In ES6 classes are not added to the global object automatically, so trying to access a class via `new window.MyClass(...)` no longer works. They are still available in the global scope though, so `new MyClass(...)` is fine.