### PR TITLE
Automatically focus on the confirmation button in ConfirmBox

### DIFF
--- a/src/main/web/common_ts/Boxes.ts
+++ b/src/main/web/common_ts/Boxes.ts
@@ -654,6 +654,13 @@ class ConfirmBox extends Box{
 		var content:HTMLDivElement=ce("div", {innerHTML: msg});
 		this.setContent(content);
 	}
+
+	onShown(){
+		super.onShown();
+		if(this.buttons.length>0){
+			this.buttons[0].focus();
+		}
+	}
 }
 
 class MessageBox extends Box{
@@ -849,4 +856,3 @@ class MobileOptionsBox extends Box{
 		this.setContent(content);
 	}
 }
-


### PR DESCRIPTION
If we don't do that, the focus remains on the last clicked link/button. If the user pressed Enter after that, the 'click' event would be fired again on the same link, which fucked up the layer hierarchy because we'd try to push _another_ ConfirmBox to the layer stack.

A nice side effect of this fix is that now it's not necessary to use the mouse when confirming stuff.
One can just press Enter.

Fixes #149