### PR TITLE
Update the album cover image through webdelta when deleting photos

### DIFF
--- a/src/main/resources/templates/desktop/photo_album_edit.twig
+++ b/src/main/resources/templates/desktop/photo_album_edit.twig
@@ -5,7 +5,7 @@
 	<div class="settingsMessage" id="albumEditMessage" style="display: none"></div>
 	<div class="inner">
 		<div class="left">
-			<div class="cover">{% if cover is not null %}{{ cover.image | pictureForPhoto('m', false) }}{% endif %}</div>
+			<div id="photoAlbumCover" class="cover">{% if cover is not null %}{{ cover.image | pictureForPhoto('m', false) }}{% endif %}</div>
 			<ul class="marginBefore actionList">
 				<li><a href="{{ album.url }}/confirmDelete" data-confirm-message="{{ L('delete_photo_album_confirm') }}" data-confirm-title="{{ L('delete_photo_album') }}" data-confirm-action="{{ album.url }}/delete">{{ L('delete_photo_album') }}</a></li>
 			</ul>
@@ -18,7 +18,7 @@
 	</div>
 </div>
 {% if items is not empty %}
-<div class="summaryWrap">
+<div id="editPhotosBlock" class="summaryWrap">
 	<div class="summary">{{ L('edit_photos') }}</div>
 	{% include "pagination" %}
 </div>
@@ -46,4 +46,3 @@
 {% script %}PhotoAlbumUploader.setupServerRenderedRows();{% endscript %}
 {% endif %}
 {% endblock %}
-


### PR DESCRIPTION
On the "Edit album" page, don't forget to set the album cover thumbnail to the actual album cover if it changes when a photo is deleted. Previously, thumbnail would contain the old album cover, and only refreshing the page would make it actual.

https://github.com/user-attachments/assets/bfed6da5-a32d-482d-ae9d-936e72d5636d


Fixes #153