### PR TITLE
Don't add newsfeed entries for missing photos

### DIFF
--- a/src/main/java/smithereen/controllers/NewsfeedController.java
+++ b/src/main/java/smithereen/controllers/NewsfeedController.java
@@ -342,6 +342,7 @@ public class NewsfeedController{
 						Map<Long, Photo> photos=context.getPhotosController().getPhotosIgnoringPrivacy(needPhotos);
 						Set<Long> needAlbums=photos.values().stream().map(p->p.albumID).collect(Collectors.toSet());
 						Map<Long, PhotoAlbum> albums=context.getPhotosController().getAlbumsIgnoringPrivacy(needAlbums);
+						newPage.removeIf(e->(e.type==NewsfeedEntry.Type.ADD_PHOTO || e.type==NewsfeedEntry.Type.PHOTO_TAG) && photos.get(e.objectID)==null);
 						for(NewsfeedEntry e:newPage){
 							if(e.type==NewsfeedEntry.Type.ADD_PHOTO || e.type==NewsfeedEntry.Type.PHOTO_TAG){
 								e.extraData=Map.of("album", albums.get(photos.get(e.objectID).albumID));


### PR DESCRIPTION
Before this commit, NPE would be thrown, and the group feed would become completely unusable as a result.

Probably fixes #148.