### PR TITLE
Fix margin on the About page

### DIFF
--- a/src/main/resources/templates/desktop/about_server.twig
+++ b/src/main/resources/templates/desktop/about_server.twig
@@ -17,6 +17,7 @@
 		<!-- right column -->
 		<td id="right">
 			<h2>{{ L('about_admins') }}</h2>
+			<div class="marginBefore">
 			<table width="100%" style="table-layout: fixed;" class="profileBlock marginAfter">
 				<colgroup><col width="48"/><col width="*"/></colgroup>
 				{% for admin in serverAdmins %}
@@ -28,6 +29,7 @@
 					</tr>
 				{% endfor %}
 			</table>
+			</div>
 			{% if serverAdminEmail is not empty %}
 				<h2>{{ L('about_contact') }}</h2>
 				<div class="marginBefore">


### PR DESCRIPTION
Before:
<img width="628" height="172" alt="Screenshot 2025-08-25 at 02 31 05" src="https://github.com/user-attachments/assets/9d5e1811-d935-40b2-9029-09aeb135fec4" />


After:
<img width="629" height="172" alt="Screenshot 2025-08-25 at 02 35 47" src="https://github.com/user-attachments/assets/460a015f-aa92-4442-b4ca-e2f3496cd2c0" />
