### PR TITLE
More verbose logging for receiving unsupported activities

### DIFF
--- a/src/main/java/smithereen/routes/ActivityPubRoutes.java
+++ b/src/main/java/smithereen/routes/ActivityPubRoutes.java
@@ -974,7 +974,7 @@ public class ActivityPubRoutes{
 				if(Config.DEBUG)
 					throw new BadRequestException("No handler found for activity type: "+getActivityType(activity));
 				else
-					LOG.error("Received and ignored an activity of an unsupported type {}", getActivityType(activity));
+					LOG.error("Received and ignored an activity of an unsupported type {}: {}", getActivityType(activity), activity.asRootActivityPubObject(ctx, req.host()));
 				return "";
 			}
 
@@ -1066,7 +1066,7 @@ public class ActivityPubRoutes{
 		if(Config.DEBUG)
 			throw new BadRequestException("No handler found for activity type: "+getActivityType(activity));
 		else
-			LOG.error("Received and ignored an activity of an unsupported type {}", getActivityType(activity));
+			LOG.error("Received and ignored an activity of an unsupported type {}: {}", getActivityType(activity), activity.asRootActivityPubObject(ctx, req.host()));
 		return "";
 	}
 


### PR DESCRIPTION
My server log contains a few messages like this:

```
[ServerThread-19282] ERROR ActivityPubRoutes - Received and ignored an activity of an unsupported type Delete
[ServerThread-20659] ERROR ActivityPubRoutes - Received and ignored an activity of an unsupported type Delete
[ServerThread-21117] ERROR ActivityPubRoutes - Received and ignored an activity of an unsupported type Delete
[ServerThread-22738] ERROR ActivityPubRoutes - Received and ignored an activity of an unsupported type Create{Note}
```

Adding more logging to see what's going on.