### PR TITLE
Fix displaying audio in comment hover card

### DIFF
--- a/src/main/web/audioplayer_desktop.scss
+++ b/src/main/web/audioplayer_desktop.scss
@@ -60,6 +60,9 @@
 		.post.comment &{
 			--audio-title-width: 430px;
 		}
+		.post.comment .commentHoverCard & {
+			--audio-title-width: 311px;
+		}
 		.columnLayout:not(.expanded) .post &{
 			--audio-title-width: 260px;
 		}


### PR DESCRIPTION
Before:
<img width="787" height="249" alt="Screenshot 2026-02-22 at 14 47 58" src="https://github.com/user-attachments/assets/f9cf37ef-f6a6-4ee5-8e05-55b80079d07d" />

After:
<img width="706" height="236" alt="Screenshot 2026-02-22 at 14 53 40" src="https://github.com/user-attachments/assets/1bc91dac-a6a0-402b-8378-f6546615c576" />

I really don't like that I have to hard-code the width here, which actually depends on the width of `commentHoverCard`, but I have no idea how to do it better.