### PR TITLE
Update admin counters via websocket notifications

### DIFF
--- a/src/main/java/smithereen/controllers/ModerationController.java
+++ b/src/main/java/smithereen/controllers/ModerationController.java
@@ -294,7 +294,7 @@ public class ModerationController{
 	private void updateReportsCounter(){
 		AdminNotifications an=AdminNotifications.getInstance(null);
 		if(an!=null){
-			an.openReportsCount=getViolationReportsCount(true);
+			an.setOpenReportsCount(getViolationReportsCount(true));
 		}
 	}
 

--- a/src/main/java/smithereen/controllers/ModerationController.java
+++ b/src/main/java/smithereen/controllers/ModerationController.java
@@ -291,10 +291,11 @@ public class ModerationController{
 		}
 	}
 
-	private void updateReportsCounter(){
+	private void updateReportsCounter() throws SQLException{
 		AdminNotifications an=AdminNotifications.getInstance(null);
 		if(an!=null){
 			an.setOpenReportsCount(getViolationReportsCount(true));
+			context.getNotificationsController().sendRealtimeCountersUpdates(UserStorage.getAdminsWithPermission(UserRole.Permission.MANAGE_REPORTS));
 		}
 	}
 
@@ -769,7 +770,7 @@ public class ModerationController{
 
 	public List<User> getPublicServerAdmins(){
 		try{
-			return UserStorage.getAdmins();
+			return UserStorage.getByIdAsList(UserStorage.getAdminsWithPermission(UserRole.Permission.VISIBLE_IN_STAFF));
 		}catch(SQLException x){
 			throw new InternalServerErrorException(x);
 		}

--- a/src/main/java/smithereen/controllers/NotificationsController.java
+++ b/src/main/java/smithereen/controllers/NotificationsController.java
@@ -14,12 +14,15 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
 import smithereen.ApplicationContext;
+import smithereen.Config;
 import smithereen.Mailer;
 import smithereen.Utils;
 import smithereen.activitypub.objects.Actor;
@@ -41,6 +44,8 @@ import smithereen.model.SizedImage;
 import smithereen.model.User;
 import smithereen.model.UserDataExport;
 import smithereen.model.UserPresence;
+import smithereen.model.admin.AdminNotifications;
+import smithereen.model.admin.UserRole;
 import smithereen.model.attachments.Attachment;
 import smithereen.model.attachments.PhotoAttachment;
 import smithereen.model.board.BoardTopic;
@@ -599,14 +604,27 @@ public class NotificationsController{
 
 	public JsonObject getUserCountersJson(Account self){
 		UserNotifications un=getUserCounters(self);
-		return new JsonObjectBuilder()
+		JsonObjectBuilder json=new JsonObjectBuilder()
 				.add("friends", un.getNewFriendRequestCount())
 				.add("photos", un.getNewPhotoTagCount())
 				.add("mail", un.getUnreadMailCount())
 				.add("groups", un.getNewGroupInvitationsCount())
 				.add("events", un.getNewEventInvitationsCount())
-				.add("notifications", un.getNewNotificationsCount())
-				.build();
+				.add("notifications", un.getNewNotificationsCount());
+
+		AdminNotifications an=AdminNotifications.getInstance(null);
+		if(an!=null) {
+			UserRole role=Config.userRoles.get(self.roleID);
+			if(role!=null) {
+				if(role.hasPermission(UserRole.Permission.MANAGE_REPORTS)){
+					json.add("adminReports", an.getOpenReportsCount());
+				}
+				if(role.hasPermission(UserRole.Permission.MANAGE_INVITES)){
+					json.add("adminSignupRequests", an.getSignupRequestsCount());
+				}
+			}
+		}
+		return json.build();
 	}
 
 	private String makeCountersWebsocketMessage(Account self){
@@ -617,16 +635,20 @@ public class NotificationsController{
 				.toString();
 	}
 
-	public void sendRealtimeCountersUpdates(User user){
-		List<WebSocketConnection> connections=null;
-		synchronized(wsMapsLock){
-			List<WebSocketConnection> actualConnections=wsConnectionsByUserID.get(user.id);
-			if(actualConnections!=null)
-				connections=new ArrayList<>(actualConnections);
-		}
+	public void sendRealtimeCountersUpdates(@NotNull User user){
+		sendRealtimeCountersUpdates(Collections.singletonList(user.id));
+	}
 
-		if(connections==null)
-			return;
+	public void sendRealtimeCountersUpdates(@NotNull Collection<Integer> userIDs){
+		if(userIDs.isEmpty()) return;
+		var connections=new ArrayList<WebSocketConnection>();
+		synchronized(wsMapsLock){
+			for(int userID : userIDs){
+				List<WebSocketConnection> actualConnections=wsConnectionsByUserID.get(userID);
+				if(actualConnections!=null)
+					connections.addAll(actualConnections);
+			}
+		}
 
 		for(WebSocketConnection conn:connections){
 			Thread.ofVirtual().start(()->conn.sendRaw(makeCountersWebsocketMessage(conn.session.account)));

--- a/src/main/java/smithereen/controllers/UsersController.java
+++ b/src/main/java/smithereen/controllers/UsersController.java
@@ -277,6 +277,7 @@ public class UsersController{
 				throw new UserErrorException("err_reg_email_taken");
 			FloodControl.OPEN_SIGNUP_OR_INVITE_REQUEST.incrementOrThrow(Utils.getRequestIP(req));
 			SessionStorage.putInviteRequest(email, firstName, lastName, reason);
+			context.getNotificationsController().sendRealtimeCountersUpdates(UserStorage.getAdminsWithPermission(UserRole.Permission.MANAGE_INVITES));
 		}catch(SQLException x){
 			throw new InternalServerErrorException(x);
 		}
@@ -301,6 +302,7 @@ public class UsersController{
 	public void deleteSignupInviteRequest(int id){
 		try{
 			SessionStorage.deleteInviteRequest(id);
+			context.getNotificationsController().sendRealtimeCountersUpdates(UserStorage.getAdminsWithPermission(UserRole.Permission.MANAGE_INVITES));
 		}catch(SQLException x){
 			throw new InternalServerErrorException(x);
 		}

--- a/src/main/java/smithereen/model/admin/AdminNotifications.java
+++ b/src/main/java/smithereen/model/admin/AdminNotifications.java
@@ -5,18 +5,42 @@ import org.jetbrains.annotations.Nullable;
 import smithereen.Utils;
 import spark.Request;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntUnaryOperator;
+
 public class AdminNotifications{
 	private static AdminNotifications instance;
 
-	public int signupRequestsCount;
-	public int openReportsCount;
+	private AtomicInteger signupRequestsCount;
+	private AtomicInteger openReportsCount;
 
-	public static AdminNotifications getInstance(@Nullable Request req){
+	@Nullable
+	public synchronized static AdminNotifications getInstance(@Nullable Request req){
 		if(instance==null && req!=null){
 			instance=new AdminNotifications();
-			instance.signupRequestsCount=Utils.context(req).getUsersController().getSignupInviteRequestCount();
-			instance.openReportsCount=Utils.context(req).getModerationController().getViolationReportsCount(true);
+			instance.signupRequestsCount=new AtomicInteger(Utils.context(req).getUsersController().getSignupInviteRequestCount());
+			instance.openReportsCount=new AtomicInteger(Utils.context(req).getModerationController().getViolationReportsCount(true));
 		}
 		return instance;
+	}
+
+	public int getSignupRequestsCount(){
+		return signupRequestsCount.get();
+	}
+
+	public void setSignupRequestsCount(int newValue){
+		signupRequestsCount.set(newValue);
+	}
+
+	public void updateSignupRequestsCount(IntUnaryOperator op){
+		signupRequestsCount.updateAndGet(op);
+	}
+
+	public int getOpenReportsCount(){
+		return openReportsCount.get();
+	}
+
+	public void setOpenReportsCount(int newValue){
+		openReportsCount.set(newValue);
 	}
 }

--- a/src/main/java/smithereen/storage/SessionStorage.java
+++ b/src/main/java/smithereen/storage/SessionStorage.java
@@ -637,7 +637,7 @@ public class SessionStorage{
 				.executeNoResult();
 		AdminNotifications an=AdminNotifications.getInstance(null);
 		if(an!=null){
-			an.signupRequestsCount=getInviteRequestCount();
+			an.setSignupRequestsCount(getInviteRequestCount());
 		}
 	}
 
@@ -668,7 +668,7 @@ public class SessionStorage{
 				.executeUpdate();
 		AdminNotifications an=AdminNotifications.getInstance(null);
 		if(an!=null)
-			an.signupRequestsCount=Math.max(0, an.signupRequestsCount-numRows);
+			an.updateSignupRequestsCount(x -> Math.max(0, x-numRows));
 	}
 
 	public static SignupRequest getInviteRequest(int id) throws SQLException{

--- a/src/main/java/smithereen/storage/UserStorage.java
+++ b/src/main/java/smithereen/storage/UserStorage.java
@@ -1231,19 +1231,19 @@ public class UserStorage{
 		accountCache.evictAll();
 	}
 
-	public static List<User> getAdmins() throws SQLException{
+	public static List<Integer> getAdminsWithPermission(UserRole.Permission permission) throws SQLException{
 		Set<Integer> rolesToShow=Config.userRoles.values()
 				.stream()
-				.filter(r->r.permissions().contains(UserRole.Permission.VISIBLE_IN_STAFF))
+				.filter(r->r.hasPermission(permission))
 				.map(UserRole::id)
 				.collect(Collectors.toSet());
 		if(rolesToShow.isEmpty())
 			return List.of();
-		return getByIdAsList(new SQLQueryBuilder()
+		return new SQLQueryBuilder()
 				.selectFrom("accounts")
 				.columns("user_id")
 				.whereIn("role", rolesToShow)
-				.executeAndGetIntList());
+				.executeAndGetIntList();
 	}
 
 	public static int getPeerDomainCount() throws SQLException{

--- a/src/main/java/smithereen/templates/Templates.java
+++ b/src/main/java/smithereen/templates/Templates.java
@@ -107,7 +107,7 @@ public class Templates{
 				jsConfig.addProperty("csrf", info.csrfToken);
 				jsConfig.addProperty("uid", info.account.user.id);
 				jsConfig.add("notifier", new JsonObjectBuilder()
-						.add("ws", UriBuilder.local().scheme("wss").path("system", "ws", "notifier").build().toString())
+						.add("ws", UriBuilder.local().scheme(Config.useHTTP ? "ws" : "wss").path("system", "ws", "notifier").build().toString())
 						.add("enabled", account.isActive() && (account.prefs.notifierTypes==null || !account.prefs.notifierTypes.isEmpty()))
 						.add("sound", account.prefs.notifierEnableSound)
 						.build()


### PR DESCRIPTION
Currently, counters like the number of signup requests or the number of moderation reports can only be updated by a full page reload. This is fixed here.