### PR TITLE
Fixes for poll layout

### DIFF
--- a/src/main/web/desktop.scss
+++ b/src/main/web/desktop.scss
@@ -2339,7 +2339,6 @@ textarea{
 
 .poll{
 	max-width: 400px;
-	padding: 6px 0 3px;
 	label{
 		display: block;
 		padding: 3px 0 0 16px;

--- a/src/main/web/desktop_basics.scss
+++ b/src/main/web/desktop_basics.scss
@@ -126,6 +126,8 @@ h3{
 }
 
 .poll{
+	padding: 6px 0 3px;
+
 	.flR.grayText{
 		padding-left: 1ch;
 	}

--- a/src/main/web/desktop_basics.scss
+++ b/src/main/web/desktop_basics.scss
@@ -126,6 +126,10 @@ h3{
 }
 
 .poll{
+	.flR.grayText{
+		padding-left: 1ch;
+	}
+
 	.pollResultRow{
 		.pollResultBarW{
 			line-height: 15px;


### PR DESCRIPTION
### First commit
Before (note how the poll title is too close to the poll kind):
<img width="60%" alt="Screenshot 2026-07-01 at 12 27 23" src="https://github.com/user-attachments/assets/5bf7d1e5-55a1-4303-bf27-cd18737173b4" />


After:
<img width="60%" alt="Screenshot 2026-07-01 at 12 27 35" src="https://github.com/user-attachments/assets/8aaf3dbe-7e0b-473f-b30c-446eb8189d66" />

### Second commit
Before (note how the poll has zero space from the image attachment):
<img width="60%" alt="Screenshot 2026-07-01 at 12 41 43" src="https://github.com/user-attachments/assets/d7764798-2f97-4cef-999a-a047dc0fa2ae" />

After:
<img width="60%" alt="Screenshot 2026-07-01 at 12 43 34" src="https://github.com/user-attachments/assets/15fc3bc3-31fd-4fe4-92e6-d11f7ed6ff2c" />
