### PR TITLE
Disable autofill in "to" field when composing mail message

### DIFF
--- a/src/main/web/common_ts/TokenInput.ts
+++ b/src/main/web/common_ts/TokenInput.ts
@@ -18,7 +18,8 @@ class TokenInput{
 		this.root=el;
 		this.completionCallback=completionCallback;
 		el.classList.add("tokenInput");
-		this.edit=ce("input", {type: "text"});
+		this.edit=ce("input", {type: "text", autocomplete: "off"});
+		this.edit.dataset.opIgnore=""; // Disable 1Password suggestions https://www.1password.dev/web/compatible-website-design#ignore-offers-to-save-or-fill-specific-fields
 		el.appendChild(this.edit);
 		this.completionList=new CompletionList(this.edit, (el)=>{
 			this.onCompletionClick(el.customData.token);


### PR DESCRIPTION
1Password would interfere with Smithereen's native autocomplete, showing a dropdown with the user's name.

`data-op-ignore` is also required on the input to hide 1Password's icon fron the input, which is completely useless.