### PR TITLE
Don't mark `audio/opus` attachments as unavailable

### DIFF
--- a/src/main/java/smithereen/templates/functions/RenderAttachmentsFunction.java
+++ b/src/main/java/smithereen/templates/functions/RenderAttachmentsFunction.java
@@ -203,6 +203,7 @@ public class RenderAttachmentsFunction implements Function{
 			"audio/aac",
 			"audio/aacp",
 			"audio/ogg",
+			"audio/opus",
 			"audio/webm",
 			"audio/flac"
 	);


### PR DESCRIPTION
`audio/opus` MIME type is supported by most modern browsers: https://caniuse.com/opus.

Example of a post with such an attachment: https://synthehai.z0ne.social/@glados_announcements/statuses/01M0Y9DZW8C134W5TJ66CV6EW7