### PR TITLE
Fix the tooltip on truncated audio titles

### DIFF
--- a/src/main/web/common_ts/AudioPlayer.ts
+++ b/src/main/web/common_ts/AudioPlayer.ts
@@ -340,7 +340,7 @@ class AudioPlayer{
 		const artist=t.qs(".artist");
 		const title=t.qs(".title");
 		if(artist.offsetWidth<artist.scrollWidth || title.offsetWidth<title.scrollWidth){
-			t.setAttribute("title", t.innerText);
+			t.setAttribute("title", `${artist.innerText}\xA0— ${title.innerText}`);
 		}else{
 			t.removeAttribute("title");
 		}


### PR DESCRIPTION
Don't display the em-dash on a separate line:

<img width="801" height="179" alt="Screenshot 2026-08-26 at 18 36 17" src="https://github.com/user-attachments/assets/bea194f8-5a4a-45d5-9bf1-cb192b1aad69" />
